### PR TITLE
Replace huds.tf links with comfig.app

### DIFF
--- a/customizations/Main Menu/[Friends] Friends Panel OFF/resource/gamemenu.res
+++ b/customizations/Main Menu/[Friends] Friends Panel OFF/resource/gamemenu.res
@@ -7,7 +7,7 @@
 	"Version"
 	{
 		"label" 									"m0rehud 6.2"
-		"command" 									"engine showconsole; echo m0rehud by Hypnotize huds.tf/site/s-m0re-Hud all credits to m0re"
+		"command" 									"engine showconsole; echo m0rehud by Hypnotize https://comfig.app/huds/page/m0rehud/ all credits to m0re"
 		"OnlyAtMenu"								"1"
 	}
 	"Servers"

--- a/customizations/Main Menu/[Friends] Friends Panel ON (Default ON)/resource/gamemenu.res
+++ b/customizations/Main Menu/[Friends] Friends Panel ON (Default ON)/resource/gamemenu.res
@@ -7,7 +7,7 @@
 	"Version"
 	{
 		"label" 									"m0rehud 6.2"
-		"command" 									"engine showconsole; echo m0rehud by Hypnotize huds.tf/site/s-m0re-Hud all credits to m0re"
+		"command" 									"engine showconsole; echo m0rehud by Hypnotize https://comfig.app/huds/page/m0rehud/ all credits to m0re"
 		"OnlyAtMenu"								"1"
 	}
 	"Servers"

--- a/resource/gamemenu.res
+++ b/resource/gamemenu.res
@@ -7,7 +7,7 @@
 	"Version"
 	{
 		"label" 									"m0rehud 6.3"
-		"command" 									"engine showconsole; echo m0rehud by Hypnotize huds.tf/site/s-m0re-Hud all credits to m0re"
+		"command" 									"engine showconsole; echo m0rehud by Hypnotize https://comfig.app/huds/page/m0rehud/ all credits to m0re"
 		"OnlyAtMenu"								"1"
 	}
 	"Servers"


### PR DESCRIPTION
[comfig.app/huds](https://comfig.app/huds) appears to be a worthy successor to huds.tf which is no longer available. This PR updates the links to huds.tf with equivalent comfig.app links.