### PR TITLE
Update hud_resolution_menu_read.res

### DIFF
--- a/resource/ui/customizations/#customization_menu/hud_resolution_menu_read.res
+++ b/resource/ui/customizations/#customization_menu/hud_resolution_menu_read.res
@@ -1,1 +1,1 @@
-#base "../../../../cfg/m0re_resolution_menu.txt"
+#base "../../../../../../cfg/m0re_resolution_menu.txt"


### PR DESCRIPTION
This needs to go 6 folders back, here it was only four, reaching to /m0rehud_m0re-x/ instead of /cfg/

It wasnt a Linux only issue.