### PR TITLE
Workaround for not being able to vote for a map

### DIFF
--- a/resource/ui/matchmakingdashboard.res
+++ b/resource/ui/matchmakingdashboard.res
@@ -530,5 +530,92 @@
 			"defaultFgColor_override"				"White"
 			"armedFgColor_override"					"White"
 		}
+		"Map1"
+		{
+			"ControlName"						"Button"
+			"fieldName"						"Map1"
+			"xpos"							"1"
+			"zpos"							"100"
+			"wide"							"24"
+			"tall"							"19"
+			"visible"						"1"
+			"textAlignment"						"center"
+			"Command"						"engine next_map_vote 0"
+			"proportionaltoparent"					"1"
+			"labeltext"						"1"
+			"actionsignallevel"					"3"
+			"roundedcorners"					"0"
+
+			"defaultFgColor_override"				"White"
+			"armedFgColor_override"					"White"
+			"depressedFgColor_override"				"White"
+
+			"defaultBgColor_override"				"TransparentBlack"
+			"armedBgColor_override"					"Menu_Accent"
+			"depressedBgColor_override"				"Menu_Accent"
+
+			"sound_depressed"					"UI/buttonclick.wav"
+
+			"pin_to_sibling"					"Map2"
+			"pin_corner_to_sibling"					"1"
+		}
+		"Map2"
+		{
+			"ControlName"						"Button"
+			"fieldName"						"Map2"
+			"xpos"							"1"
+			"zpos"							"100"
+			"wide"							"24"
+			"tall"							"19"
+			"visible"						"1"
+			"textAlignment"						"center"
+			"Command"						"engine next_map_vote 1"
+			"proportionaltoparent"					"1"
+			"labeltext"						"2"
+			"actionsignallevel"					"3"
+			"roundedcorners"					"0"
+
+			"defaultFgColor_override"				"White"
+			"armedFgColor_override"					"White"
+			"depressedFgColor_override"				"White"
+
+			"defaultBgColor_override"				"TransparentBlack"
+			"armedBgColor_override"					"Menu_Accent"
+			"depressedBgColor_override"				"Menu_Accent"
+
+			"sound_depressed"					"UI/buttonclick.wav"
+
+			"pin_to_sibling"					"Map3"
+			"pin_corner_to_sibling"					"1"
+		}
+		"Map3"
+		{
+			"ControlName"						"Button"
+			"fieldName"						"Map3"
+			"xpos"							"1"
+			"zpos"							"100"
+			"wide"							"24"
+			"tall"							"19"
+			"visible"						"1"
+			"textAlignment"						"center"
+			"Command"						"engine next_map_vote 2"
+			"proportionaltoparent"					"1"
+			"labeltext"						"3"
+			"actionsignallevel"					"3"
+			"roundedcorners"					"0"
+
+			"sound_depressed"					"UI/buttonclick.wav"
+
+			"defaultFgColor_override"				"White"
+			"armedFgColor_override"					"White"
+			"depressedFgColor_override"				"White"
+
+			"defaultBgColor_override"				"TransparentBlack"
+			"armedBgColor_override"					"Menu_Accent"
+			"depressedBgColor_override"				"Menu_Accent"
+
+			"pin_to_sibling"					"ResumeButton"
+			"pin_corner_to_sibling"					"1"
+		}
 	}
 }


### PR DESCRIPTION
Sometimes in Casual you cannot vote for a map at the end of a round. To reproduce this bug, play Casual until you see it, unfortunately it is not known exactly how this happens.
![morehud map vote bug workaround](https://github.com/Hypnootize/m0rehud/assets/117596825/0bedb9c6-aed2-4eae-8eb9-611b6f546176)