### PR TITLE
Update gamemenu.res

### DIFF
--- a/resource/gamemenu.res
+++ b/resource/gamemenu.res
@@ -124,7 +124,7 @@
 	"Fix_Visual_Glitches"
 	{
 		"label"										"D"
-		"command"									"engine stop; ds_record"
+		"command"									"record m0re_fix_visual_glitches; stop"
 		"tooltip"									"Fix Visual Glitches"
 		"OnlyInGame"								"1"
 	}


### PR DESCRIPTION
"Fix_Visual_Glitches" had the commands "ds_record" and "stop" switched around. This created the effect of the game recording a demo until the hud user manually stopped it. I switched them around and changed the command "ds_record" to "record" because using ds_record stopped the demo immediately but still saved it, taking up disk pace unnecessarily.