### PR TITLE
Update gamemenu.res

### DIFF
--- a/resource/gamemenu.res
+++ b/resource/gamemenu.res
@@ -124,7 +124,7 @@
 	"Fix_Visual_Glitches"
 	{
 		"label"										"D"
-		"command"									"engine stop; ds_record"
+		"command"									"record m0re_fix_visual_glitches; stop"
 		"tooltip"									"Fix Visual Glitches"
 		"OnlyInGame"								"1"
 	}

--- a/resource/gamemenu.res
+++ b/resource/gamemenu.res
@@ -124,7 +124,7 @@
 	"Fix_Visual_Glitches"
 	{
 		"label"										"D"
-		"command"									"record m0re_fix_visual_glitches; stop"
+		"command"									"engine record m0re_fix_visual_glitches; stop"
 		"tooltip"									"Fix Visual Glitches"
 		"OnlyInGame"								"1"
 	}


### PR DESCRIPTION
"Fix_Visual_Glitches" had the commands "ds_record" and "stop" switched around. This created the effect of the game recording a demo until the hud user manually stopped it. I switched them around and changed the command "ds_record" to "record" because using ds_record stopped the demo immediately but still saved the .json file, taking up disk space unnecessarily. If you notice poor video quality. it's because I had to keep the file size low. The original videos I tried to send were too large for GitHub. Also, turn on the sound to better understand what's happening.

Before:

https://github.com/Hypnootize/m0rehud/assets/174676548/556db54b-a2ff-4fde-a564-20f050a0336a

After:

https://github.com/Hypnootize/m0rehud/assets/174676548/864e897a-e191-434e-9875-df2726f0e5b6

After dns_ Version:

https://github.com/Hypnootize/m0rehud/assets/174676548/fbe6cb0b-4242-43b0-a5fa-2ece5c0e88d2

Here's the .json file the dns_ version hud produced:

[2024-07-06_05-55-00.json](https://github.com/user-attachments/files/16115748/2024-07-06_05-55-00.json)
